### PR TITLE
docs: alternative for git clone

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,10 @@
 Damaged files made by Johan van der Knijff: 
 <http://openpreservation.org/blog/2017/01/04/breaking-waves-and-some-flacs/>
 <https://github.com/KBNLresearch/detectDamagedAudio>
+
+If `git clone` gives you problems as your file system does not like the silly file names, then note
+that GitHub offers [a download in ZIP format][download]. Windows Explorer does not like that ZIP
+file either but using, e.g., [7-Zip][7zip] you can select the folders you want to extract.
+
+[download]: https://github.com/IISH/archivematica-test-collections/archive/refs/heads/master.zip
+[7zip]: https://www.7-zip.org/


### PR DESCRIPTION
Just a quick hint to circumvent the following on Windows:

```text
$ git clone https://github.com/IISH/archivematica-test-collections.git
Cloning into 'archivematica-test-collections'...
remote: Enumerating objects: 205, done.
remote: Total 205 (delta 0), reused 0 (delta 0), pack-reused 205
Receiving objects: 100% (205/205), 201.98 MiB | 14.30 MiB/s, done.
Resolving deltas: 100% (25/25), done.
error: invalid path '14 - Silly filenames/*."[]:;|=,.txt'
fatal: unable to checkout working tree
warning: Clone succeeded, but checkout failed.
You can inspect what was checked out with 'git status'
and retry with 'git restore --source=HEAD :/'
```